### PR TITLE
Fixed padding issue

### DIFF
--- a/src/org/vaadin/resetbuttonfortextfield/widgetset/public/resetbuttonfortextfield/styles.css
+++ b/src/org/vaadin/resetbuttonfortextfield/widgetset/public/resetbuttonfortextfield/styles.css
@@ -7,6 +7,7 @@
     display: inline-block;
     vertical-align: bottom;
     right: 15pt;
+    margin-right: -15pt;
     top: -3pt;
     cursor: pointer;
     width: 16px;


### PR DESCRIPTION
Added a negative right margin to the reset button to prevent it pushing following components when used in a HorizontalLayout.
